### PR TITLE
Update __init__.py

### DIFF
--- a/headers/__init__.py
+++ b/headers/__init__.py
@@ -39,7 +39,7 @@ class NoHeaderError(Exception):
 
 def get_template(file_path):
     _, file_name = split(file_path)
-    dot_index = file_name.find('.')
+    dot_index = file_name.rfind('.')
     extension = file_name[dot_index + 1:]
 
     try:


### PR DESCRIPTION
The get_template() function used .find() method to find the dot that separates the filename from the extension.

Because of that, headers didn't work with files that contained a dot in the filename, i.e.:

`Robot.class.cpp` doesn't match the 'cpp' extension, because .find() will return the index of the first dot. The function then believes the extension is 'class.cpp'. It is, therefore, impossible to have a working header in this kind of file.

If we use .rfind() instead, these files will be matched correctly.