### PR TITLE
Add a SOFT setting to prevent to overwrite redo stack of command_history

### DIFF
--- a/main.py
+++ b/main.py
@@ -85,4 +85,6 @@ class update_headerCommand(TextCommand):
 class eventListener(EventListener):
 
     def on_pre_save(self, view):
-        view.window().run_command('update_header')
+        str, dict, index = view.command_history(1, True)
+        if index == 0 or not settings.SOFT:
+            view.window().run_command('update_header')

--- a/settings.py
+++ b/settings.py
@@ -10,6 +10,7 @@ class Settings:
 
     DATE_TIME_FORMAT = '%Y/%m/%d %H:%M:%S'
 
+    # If SOFT is True, the update is only done if the redo stack is empty
     SOFT = False
 
     def __init__(self):

--- a/settings.py
+++ b/settings.py
@@ -10,6 +10,8 @@ class Settings:
 
     DATE_TIME_FORMAT = '%Y/%m/%d %H:%M:%S'
 
+    SOFT = False
+
     def __init__(self):
         self.all = load_settings(Settings.SETTINGS_FILE)
 


### PR DESCRIPTION
Hi,

I add a SOFT setting to prevent to erase redo stack on update. If SOFT is true, the update is done only if the redo stack is None (empty).